### PR TITLE
Don’t require the `page` variable

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -25,7 +25,7 @@ module.exports = (config) => {
       const parsed = parse(inputPath)
       if (parsed.name.startsWith('_')) return
 
-      return async ({page}) => engine.processCSS(input, {inputPath, outputPath: page.outputPath})
+      return async ({page}) => engine.processCSS(input, {inputPath, outputPath: page && page.outputPath})
     }
   })
 }


### PR DESCRIPTION
The Render plugin doesn’t set it, and so `renderTemplate("…", "css")` failed. Since it doesn’t seem to actually be required, make it work without `page`.